### PR TITLE
Feat: Auto-restore screensaver and hypridle when exiting Game Mode

### DIFF
--- a/setup-gaming-mode.sh
+++ b/setup-gaming-mode.sh
@@ -102,6 +102,32 @@ create_gaming_script() {
 #!/bin/bash
 # Launch gaming mode with current display resolution and refresh rate
 
+# Cleanup function to restore Idle lock
+# This runs automatically when the script exits (successfully or interrupted)
+restore_system_state() {
+    echo "Steam session ended. Restoring system services..."
+    
+    # 1. Restore Screensaver (Omarchy specific)
+    STATE_FILE=~/.local/state/omarchy/toggles/screensaver-off
+    if [[ -f $STATE_FILE ]]; then
+        rm "$STATE_FILE"
+        echo "Removed screensaver inhibit file."
+    fi
+
+    # 2. Restore Hypridle (Idle lock)
+    # Check if hypridle is running; if not, start it in the background
+    if ! pgrep -x "hypridle" > /dev/null; then
+        echo "Restarting hypridle..."
+        hypridle >/dev/null 2>&1 & 
+        # Note: Using & to background it so it survives this script exiting
+    fi
+
+    notify-send "Gaming Mode Ended" "Screensaver and Idle Lock re-enabled."
+}
+
+# Register the trap to run the function above on EXIT
+trap restore_system_state EXIT
+
 # Function to detect and kill running Steam instances
 kill_steam_instances() {
   local steam_pids
@@ -219,7 +245,7 @@ else
 fi
 
 # Launch gamescope as nested session with current display settings
-exec /usr/bin/gamescope --mangoapp -f -W "$WIDTH" -H "$HEIGHT" -r "$REFRESH" -e -- /usr/bin/steam -tenfoot
+/usr/bin/gamescope --mangoapp -f -W "$WIDTH" -H "$HEIGHT" -r "$REFRESH" -e -- /usr/bin/steam -tenfoot
 EOF
   
   sudo chmod +x /usr/local/bin/switch-to-gaming


### PR DESCRIPTION
Hi there!
First off, huge thanks for putting this script together, it's been working great on my setup.
I made a small tweak for myself on the switch script because I found I kept forgetting to manually re-enable my screensaver and idle lock after I finished gaming. I figured I would submit this PR in case you wanted to include this quality-of-life improvement for everyone else.

Here is a summary of what I changed:
## Summary
This PR updates the gaming mode switch launch script to automatically re-enable system features (screensaver and idle lock) after the Steam session ends.

## Motivation
Currently, the script disables `hypridle` and creates the `screensaver-off` toggle file before launching Steam. However, because it uses `exec`, the script terminates immediately upon launch. This requires manual intervention to restore them after they exit Steam.

## Changes
- Removed `exec` from the final gamescope command to keep the script process alive.
- Added a `restore_system_state` function that:
  - Removes the `~/.local/state/omarchy/toggles/screensaver-off` file.
  - Checks if `hypridle` is running, and restarts it if it is not.
- Implemented a `trap restore_system_state EXIT` hook. This ensures the cleanup runs regardless of whether Steam is closed normally or the script is interrupted (SIGINT/SIGTERM).

## Testing
- Verified that `hypridle` is killed and the toggle file is created on launch.
- Verified that `hypridle` restarts and the toggle file is removed immediately after exiting Steam.